### PR TITLE
Update projects to net6.0

### DIFF
--- a/SyncChanges.Console/SyncChanges.Console.csproj
+++ b/SyncChanges.Console/SyncChanges.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Description>Synchronize/Replicate database changes using SQL Server Change Tracking</Description>
     <Copyright>Copyright 2013-$([System.DateTime]::Now.Year) Michael Ganss</Copyright>
     <AssemblyTitle>SyncChanges.Console</AssemblyTitle>

--- a/SyncChanges.Tests/SyncChanges.Tests.csproj
+++ b/SyncChanges.Tests/SyncChanges.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <SonarQubeExclude>true</SonarQubeExclude>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 3.0.{build}
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2022
 environment:
   access_token:
     secure: Eq6BjtZ80BXKLwFMg76IjuQAvbLjbojIF/X/ARouGVhxPneJtgDfCXMPNgJ7KBKq

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,12 @@ build_script:
   - dotnet --info
   - dotnet restore
   - dotnet build -c Release
-  - dotnet publish SyncChanges.Console -c Release -f net5.0
+  - dotnet publish SyncChanges.Console -c Release -f net6.0
   - dotnet publish SyncChanges.Service -c Release -f net461
   - dotnet pack --include-symbols --include-source -c Release SyncChanges
   - dotnet pack --include-symbols --include-source -c Release SyncChanges.Console
   - dotnet pack --include-symbols --include-source -c Release SyncChanges.Service
-  - 7z a -mx=9 SyncChanges.Console.%APPVEYOR_BUILD_VERSION%.zip ".\SyncChanges.Console\bin\Release\net5.0\publish\*"
+  - 7z a -mx=9 SyncChanges.Console.%APPVEYOR_BUILD_VERSION%.zip ".\SyncChanges.Console\bin\Release\net6.0\publish\*"
   - 7z a -mx=9 SyncChanges.Service.%APPVEYOR_BUILD_VERSION%.zip ".\SyncChanges.Service\bin\Release\net461\publish\*"
 test_script:
   - ps: |


### PR DESCRIPTION
.Net 5.0 has reached end of life, meaning it is no longer supported.