### PR TITLE
Delete before insert inside same version

### DIFF
--- a/SyncChanges/Synchronizer.cs
+++ b/SyncChanges/Synchronizer.cs
@@ -457,7 +457,7 @@ namespace SyncChanges
                         from CHANGETABLE (CHANGES {tableName}, @0) c
                         left outer join {tableName} t on ";
                     sql += string.Join(" and ", table.KeyColumns.Select(k => $"c.{k} = t.{k}"));
-                    sql += " order by coalesce(c.SYS_CHANGE_CREATION_VERSION, c.SYS_CHANGE_VERSION)";
+                    sql += " order by coalesce(c.SYS_CHANGE_CREATION_VERSION, c.SYS_CHANGE_VERSION), c.SYS_CHANGE_OPERATION";
 
                     Log.Debug($"Retrieving changes for table {tableName}: {sql}");
 


### PR DESCRIPTION
Ran into issue when application sets up transaction that deletes and inserts a new row (with a new identity id). If this is applied in incorrect order and there is an index which has a unique constraint this will cause insert to fail because the previous row has not been deleted yet.

This solves the issue by running following order delete->insert->update.

Here is an example of the table with composite PK with identity:

![image](https://github.com/mganss/SyncChanges/assets/11734687/1f9016a4-ddcd-4763-b33c-ad6879268c81)
