### PR TITLE
VARBINARY does NULL is not mapped correctly by default

### DIFF
--- a/SyncChanges/DataReaderExtensions.cs
+++ b/SyncChanges/DataReaderExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.SqlTypes;
+using System.Text;
+
+namespace SyncChanges
+{
+    internal static class DataReaderExtensions
+    {
+
+        public static object[] GetNullableTypeMap(this DbDataReader reader)
+        {
+
+            var nullTypeMap = new object[reader.FieldCount];
+
+            for (int i = 0; i < nullTypeMap.Length; i++)
+            {
+                if (reader.IsDBNull(i))
+                {
+                    switch (reader.GetDataTypeName(i).ToUpper())
+                    {
+                        case "VARBINARY":
+                            nullTypeMap[i] = SqlBinary.Null;
+                            break;
+                    }
+                }
+            }
+
+            return nullTypeMap;
+        }
+
+
+    }
+}


### PR DESCRIPTION
VARBINARY seems to be a special case which does not work correctly:

```
2024-08-05 19:06:04.7033|INFO|Getting replication information for replication set Test
2024-08-05 19:06:07.3604|INFO|Replicating table [dbo].[test2]
2024-08-05 19:06:07.3604|INFO|Starting replication for replication set Test
2024-08-05 19:06:07.3604|INFO|Database Secondary 1 is at version 24994
2024-08-05 19:06:07.3771|INFO|Snapshot isolation is enabled in database Primary
2024-08-05 19:06:07.3771|INFO|Current version of database Primary is 24997
2024-08-05 19:06:07.4134|INFO|Minimum version of table [dbo].[test2] in database Primary is 24984
2024-08-05 19:06:07.4134|DEBUG|Retrieving changes for table [dbo].[test2]: select c.SYS_CHANGE_OPERATION, c.SYS_CHANGE_VERSION, c.SYS_CHANGE_CREATION_VERSION,
                        c.[id], t.[dat]
                        from CHANGETABLE (CHANGES [dbo].[test2], @0) c
                        left outer join [dbo].[test2] t on c.[id] = t.[id] order by coalesce(c.SYS_CHANGE_CREATION_VERSION, c.SYS_CHANGE_VERSION), c.SYS_CHANGE_OPERATION
2024-08-05 19:06:07.4314|INFO|Table [dbo].[test2] has 1 change
2024-08-05 19:06:07.4368|INFO|Replicating 1 change to destination Secondary 1
2024-08-05 19:06:07.4368|DEBUG|Replicating change #1 of 1 (Version 24997, CreationVersion 24997)
2024-08-05 19:06:07.4368|DEBUG|Executing insert: set IDENTITY_INSERT [dbo].[test2] ON; insert into [dbo].[test2] ([id], [dat]) values (@0, @1); set IDENTITY_INSERT [dbo].[test2] OFF (@0 = 4, @1 = )
2024-08-05 19:06:07.4540|ERROR|Error replicating changes to destination Secondary 1 System.Data.SqlClient.SqlException (0x80131904): Implicit conversion from data type nvarchar to varbinary(max) is not allowed. Use the CONVERT function to run this query.
   at System.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
   at System.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, Boolean callerHasConnectionLock, Boolean asyncClose)
   at System.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, Boolean& dataReady)
   at System.Data.SqlClient.SqlCommand.FinishExecuteReader(SqlDataReader ds, RunBehavior runBehavior, String resetOptionsString)
   at System.Data.SqlClient.SqlCommand.RunExecuteReaderTds(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, Boolean async, Int32 timeout, Task& task, Boolean asyncWrite, SqlDataReader ds)
   at System.Data.SqlClient.SqlCommand.InternalExecuteNonQuery(TaskCompletionSource`1 completion, Boolean sendToPipe, Int32 timeout, Boolean asyncWrite, String methodName)
   at System.Data.SqlClient.SqlCommand.ExecuteNonQuery()
   at NPoco.Database.ExecuteNonQueryHelper(DbCommand cmd)
   at NPoco.Database.Execute(String sql, CommandType commandType, Object[] args)
   at SyncChanges.Synchronizer.PerformChange(Database db, Change change) in R:\Projects\IF\Sync2\SyncChanges\SyncChanges\Synchronizer.cs:line 563
   at SyncChanges.Synchronizer.Replicate(DatabaseInfo source, IGrouping`2 destinations, IList`1 tables) in R:\Projects\IF\Sync2\SyncChanges\SyncChanges\Synchronizer.cs:line 349
ClientConnectionId:1e0c653d-c85e-4ced-88b6-eeaa8197277b
Error Number:257,State:3,Class:16 HelpLink.ProdName: Microsoft SQL Server;HelpLink.ProdVer: 14.00.3411;HelpLink.EvtSrc: MSSQLServer;HelpLink.EvtID: 257;HelpLink.BaseHelpUrl: https://go.microsoft.com/fwlink;HelpLink.LinkId: 20476
2024-08-05 19:06:07.4818|INFO|Finished replication with errors
```

To work around this - check which columns can be nullable and are varbinary (maybe there are some more types?) - then insert SqlBinary.Null
